### PR TITLE
Add null check for transaction hash before saving vote

### DIFF
--- a/src/main/java/com/example/votingbackend/service/VotingService.java
+++ b/src/main/java/com/example/votingbackend/service/VotingService.java
@@ -79,6 +79,9 @@ public class VotingService {
         vote.setTimestamp(LocalDateTime.now());
         
         try {
+            if(vote.getTransactionHash()==null){
+                throw new Exception("Transaction hash is null");
+            }
             voteRepo.save(vote);
             System.out.println("✅ Vote saved to database");
         } catch (Exception e) {


### PR DESCRIPTION
A check was added to ensure the transaction hash is not null before saving a vote. If the transaction hash is null, an exception is thrown to prevent invalid data from being persisted.